### PR TITLE
feat(conditionals): Implement conditional support

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -44,7 +44,7 @@ func prepareNodeName(rawName string) lexer.AST {
 		case stateLiteral:
 			if chr == '$' && lastRune != '\\' {
 				if tmp.Len() > 0 {
-					ast = append(ast, lexer.Literal(tmp.String()))
+					ast = append(ast, lexer.Literal{String: tmp.String()})
 					tmp.Reset()
 				}
 
@@ -88,12 +88,12 @@ func prepareNodeName(rawName string) lexer.AST {
 	}
 	if s == stateLiteral {
 		if tmp.Len() > 0 {
-			ast = append(ast, lexer.Literal(tmp.String()))
+			ast = append(ast, lexer.Literal{String: tmp.String()})
 		}
 	} else {
-		ast = append(ast, lexer.Literal(fmt.Sprintf("$%s", tmp.String())))
+		ast = append(ast, lexer.Literal{String: fmt.Sprintf("$%s", tmp.String())})
 		if format.Len() > 0 {
-			ast = append(ast, lexer.Literal(fmt.Sprintf("__%s", format.String())))
+			ast = append(ast, lexer.Literal{String: fmt.Sprintf("__%s", format.String())})
 		}
 	}
 	return ast

--- a/lexer/errors.go
+++ b/lexer/errors.go
@@ -9,7 +9,7 @@ type UnexpectedEOFErr struct {
 }
 
 func (u UnexpectedEOFErr) Error() string {
-	return fmt.Sprintf("Unexpected end of input at line %d (index %d). Tokenizer state was %d", u.line+1, u.idx, u.state)
+	return fmt.Sprintf("Unexpected end of input at line %d (index %d). Tokenizer state was %s", u.line+1, u.idx, u.state)
 }
 
 type UnexpectedLinebreakErr struct {
@@ -29,4 +29,24 @@ type UnexpectedTokenErr struct {
 
 func (u UnexpectedTokenErr) Error() string {
 	return fmt.Sprintf("Unexpected token `%s' at line %d (index %d)", u.token, u.line+1, u.idx)
+}
+
+type UnsupportedConditionalHelperErr struct {
+	idx    int
+	helper string
+	line   int
+}
+
+func (u UnsupportedConditionalHelperErr) Error() string {
+	return fmt.Sprintf("Unsupported conditional helper `%s' at line %d (index %d)", u.helper, u.line+1, u.idx)
+}
+
+type InvalidConditionalExpressionErr struct {
+	idx  int
+	line int
+	expr string
+}
+
+func (u InvalidConditionalExpressionErr) Error() string {
+	return fmt.Sprintf("Invalid conditional expression `%s' at line %d (index %d)", u.expr, u.line+1, u.idx)
 }

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -142,6 +142,16 @@ func isSpace(r rune) bool {
 	return r == SPACE || r == HTAB
 }
 
+type stateStack []state
+
+func (s *stateStack) String() string {
+	result := make([]string, 0, len(*s))
+	for _, v := range *s {
+		result = append(result, v.String())
+	}
+	return strings.Join(result, ", ")
+}
+
 type Tokenizer struct {
 	ast AST
 	tmp *sb.StringBuilder
@@ -152,7 +162,7 @@ type Tokenizer struct {
 	templateOptions    map[string]string
 	_state             state
 	currentConditional *Conditional
-	stateStack         []state
+	stateStack         stateStack
 
 	lastFedRune rune
 	idx         int

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -187,10 +187,13 @@ func NewTokenizer() *Tokenizer {
 
 func (t *Tokenizer) pushStack() {
 	t.stateStack = append(t.stateStack, t._state)
+	if DEBUG {
+		debug("STS: PUSH [%s]", t.stateStack.String())
+	}
 }
 
 func (t *Tokenizer) transition(s state) {
-	debug("Transitioning from %s to %s\n", t._state, s)
+	debug("STT: Transitioning %s -> %s", t._state, s)
 	t._state = s
 }
 
@@ -200,6 +203,9 @@ func (t *Tokenizer) popStack() state {
 	}
 	t.transition(t.stateStack[len(t.stateStack)-1])
 	t.stateStack = t.stateStack[0 : len(t.stateStack)-1]
+	if DEBUG {
+		debug("STS: POP [%s]", t.stateStack.String())
+	}
 	return t._state
 }
 
@@ -208,6 +214,9 @@ func (t *Tokenizer) replaceStack(s state) {
 		panic("BUG? Attempt to replace on empty state stack")
 	}
 	t.stateStack[len(t.stateStack)-1] = s
+	if DEBUG {
+		debug("STS: REPLACE [%s]", t.stateStack.String())
+	}
 }
 
 func (t *Tokenizer) currentStack() (bool, state) {
@@ -265,7 +274,7 @@ func (t *Tokenizer) commitTemplateOption() {
 
 func (t *Tokenizer) prepareConditional() error {
 	ok, ls := t.currentStack()
-	debug("prepareConditional: Current state: %s, lastStack(%v): %s\n", t._state, ok, ls)
+	debug("CND: Current state: %s, lastStack(%v): %s", t._state, ok, ls)
 	expr := t.templateName.String()
 	separatorIndex := strings.IndexRune(expr, DOT)
 	if separatorIndex == -1 {
@@ -335,7 +344,7 @@ func (t *Tokenizer) Feed(chr rune) error {
 		if pchr == "\n" {
 			pchr = "\\n"
 		}
-		debug("CHR: %s, STATE: %s\n", pchr, t._state)
+		debug("CHR: %s, STATE: %s", pchr, t._state)
 	}
 	switch t._state {
 	case stateLiteral:

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -413,6 +413,13 @@ func (t *Tokenizer) Feed(chr rune) error {
 			if t.templateName.String() == "if" {
 				t.transition(stateTemplateConditionalThen)
 			} else {
+				// Transitioning to ElseIf...
+				if ok, current := t.currentStack(); !ok || current == stateTemplateConditionalElse {
+					// At this point we either have an elseif out of an if
+					// structure, or we have an elseif after an else. Both are
+					// unacceptable.
+					return t.unexpectedKeyword("elseif")
+				}
 				t.transition(stateTemplateConditionalElseIf)
 			}
 			t.pushStack()

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -1,40 +1,142 @@
 package lexer
 
 import (
+	"fmt"
+	"reflect"
 	"strings"
 	"unicode"
 
 	"github.com/Gympass/go-giter8/sb"
 )
 
-type Literal string
-type Template struct {
-	Name    string
-	Options map[string]string
+type Kind int
+
+const (
+	KindInvalid Kind = iota
+	KindLiteral
+	KindTemplate
+	KindConditional
+)
+
+const DEBUG = false
+
+func debug(format string, a ...interface{}) {
+	if DEBUG {
+		fmt.Printf("%s\n", fmt.Sprintf(format, a...))
+	}
 }
 
-type AST []interface{}
+type Node interface {
+	Kind() Kind
+	Parent() Node
+}
+
+type Literal struct {
+	String     string
+	nodeParent Node
+}
+
+func (l Literal) Kind() Kind {
+	return KindLiteral
+}
+
+func (l Literal) Parent() Node {
+	return l.nodeParent
+}
+
+type Template struct {
+	Name       string
+	Options    map[string]string
+	nodeParent Node
+}
+
+func (t Template) Parent() Node {
+	return t.nodeParent
+}
+
+func (t Template) Kind() Kind {
+	return KindTemplate
+}
+
+type Conditional struct {
+	Property   string
+	Helper     string
+	Then       AST
+	ElseIf     []*Conditional
+	Else       AST
+	parentNode Node
+}
+
+func (c Conditional) Kind() Kind {
+	return KindConditional
+}
+
+func (c Conditional) Parent() Node {
+	return c.parentNode
+}
+
+type AST []Node
 
 type state int
 
 const (
 	stateLiteral state = iota
 	stateTemplateName
+	stateTemplateConditionalExpression
+	stateTemplateConditionalExpressionEnd
+	stateTemplateConditionalThen
+	stateTemplateConditionalElseIf
+	stateTemplateConditionalElse
 	stateTemplateOptionName
 	stateTemplateOptionValueBegin
 	stateTemplateOptionValue
 	stateTemplateOptionOrEnd
 )
 
-const ESCAPE = rune('\\')
-const DELIM = rune('$')
-const NEWLINE = rune('\n')
-const SEMICOLON = rune(';')
-const EQUALS = rune('=')
-const QUOT = rune('"')
-const COMMA = rune(',')
-const SPACE = rune(' ')
-const HTAB = rune('\t')
+func (s state) String() string {
+	switch s {
+	case stateLiteral:
+		return "stateLiteral"
+	case stateTemplateName:
+		return "stateTemplateName"
+	case stateTemplateConditionalExpression:
+		return "stateTemplateConditionalExpression"
+	case stateTemplateConditionalExpressionEnd:
+		return "stateTemplateConditionalExpressionEnd"
+	case stateTemplateConditionalThen:
+		return "stateTemplateConditionalThen"
+	case stateTemplateConditionalElseIf:
+		return "stateTemplateConditionalElseIf"
+	case stateTemplateConditionalElse:
+		return "stateTemplateConditionalElse"
+	case stateTemplateOptionName:
+		return "stateTemplateOptionName"
+	case stateTemplateOptionValueBegin:
+		return "stateTemplateOptionValueBegin"
+	case stateTemplateOptionValue:
+		return "stateTemplateOptionValue"
+	case stateTemplateOptionOrEnd:
+		return "stateTemplateOptionOrEnd"
+	default:
+		return "WTF!"
+	}
+}
+
+const (
+	ESCAPE    = rune('\\')
+	DELIM     = rune('$')
+	NEWLINE   = rune('\n')
+	SEMICOLON = rune(';')
+	EQUALS    = rune('=')
+	QUOT      = rune('"')
+	COMMA     = rune(',')
+	SPACE     = rune(' ')
+	HTAB      = rune('\t')
+	LPAREN    = rune('(')
+	RPAREN    = rune(')')
+	DOT       = rune('.')
+	TRUTHY    = "truthy"
+)
 
 func isSpace(r rune) bool {
 	return r == SPACE || r == HTAB
@@ -44,11 +146,13 @@ type Tokenizer struct {
 	ast AST
 	tmp *sb.StringBuilder
 
-	templateName    *sb.StringBuilder
-	optionName      *sb.StringBuilder
-	optionValue     *sb.StringBuilder
-	templateOptions map[string]string
-	state           state
+	templateName       *sb.StringBuilder
+	optionName         *sb.StringBuilder
+	optionValue        *sb.StringBuilder
+	templateOptions    map[string]string
+	_state             state
+	currentConditional *Conditional
+	stateStack         []state
 
 	lastFedRune rune
 	idx         int
@@ -64,10 +168,54 @@ func NewTokenizer() *Tokenizer {
 		optionName:      sb.New(),
 		optionValue:     sb.New(),
 		templateOptions: nil,
-		state:           0,
+		_state:          0,
 		lastFedRune:     0,
 		idx:             0,
 		line:            0,
+	}
+}
+
+func (t *Tokenizer) pushStack() {
+	t.stateStack = append(t.stateStack, t._state)
+}
+
+func (t *Tokenizer) transition(s state) {
+	debug("Transitioning from %s to %s\n", t._state, s)
+	t._state = s
+}
+
+func (t *Tokenizer) popStack() state {
+	if len(t.stateStack) == 0 {
+		panic("BUG? Attempt to pop state stack beyond limit")
+	}
+	t.transition(t.stateStack[len(t.stateStack)-1])
+	t.stateStack = t.stateStack[0 : len(t.stateStack)-1]
+	return t._state
+}
+
+func (t *Tokenizer) replaceStack(s state) {
+	if len(t.stateStack) == 0 {
+		panic("BUG? Attempt to replace on empty state stack")
+	}
+	t.stateStack[len(t.stateStack)-1] = s
+}
+
+func (t *Tokenizer) currentStack() (bool, state) {
+	if len(t.stateStack) == 0 {
+		return false, 0
+	}
+	return true, t.stateStack[len(t.stateStack)-1]
+}
+
+func (t *Tokenizer) pushAST(n Node) {
+	if ok, s := t.currentStack(); ok {
+		if s == stateTemplateConditionalThen || s == stateTemplateConditionalElseIf {
+			t.currentConditional.Then = append(t.currentConditional.Then, n)
+		} else {
+			t.currentConditional.Else = append(t.currentConditional.Else, n)
+		}
+	} else {
+		t.ast = append(t.ast, n)
 	}
 }
 
@@ -75,7 +223,7 @@ func (t *Tokenizer) commitLiteral() {
 	if t.tmp.Len() == 0 {
 		return
 	}
-	t.ast = append(t.ast, Literal(t.tmp.String()))
+	t.pushAST(&Literal{String: t.tmp.String(), nodeParent: t.currentConditional})
 	t.tmp.Reset()
 }
 
@@ -83,9 +231,10 @@ func (t *Tokenizer) commitTemplate() {
 	if t.templateName.Len() == 0 {
 		return
 	}
-	t.ast = append(t.ast, Template{
-		Name:    strings.TrimSpace(t.templateName.String()),
-		Options: t.templateOptions,
+	t.pushAST(&Template{
+		Name:       strings.TrimSpace(t.templateName.String()),
+		Options:    t.templateOptions,
+		nodeParent: t.currentConditional,
 	})
 	t.templateName.Reset()
 	t.templateOptions = nil
@@ -104,6 +253,40 @@ func (t *Tokenizer) commitTemplateOption() {
 	t.optionValue.Reset()
 }
 
+func (t *Tokenizer) prepareConditional() error {
+	ok, ls := t.currentStack()
+	debug("prepareConditional: Current state: %s, lastStack(%v): %s\n", t._state, ok, ls)
+	expr := t.templateName.String()
+	separatorIndex := strings.IndexRune(expr, DOT)
+	if separatorIndex == -1 {
+		return t.invalidConditionalExpression(expr)
+	}
+	var (
+		prop   = expr[0:separatorIndex]
+		helper = expr[separatorIndex+1:]
+	)
+
+	if !strings.EqualFold(helper, TRUTHY) {
+		return t.unsupportedConditionalHelper(helper)
+	}
+
+	cond := &Conditional{
+		Property:   prop,
+		Helper:     helper,
+		Then:       nil,
+		Else:       nil,
+		parentNode: t.currentConditional,
+	}
+	if ls == stateTemplateConditionalThen {
+		t.ast = append(t.ast, cond)
+	} else if ls == stateTemplateConditionalElseIf {
+		t.currentConditional.ElseIf = append(t.currentConditional.ElseIf, cond)
+	}
+	t.currentConditional = cond
+	t.templateName.Reset()
+	return nil
+}
+
 func (t *Tokenizer) lastRune() rune {
 	return t.lastFedRune
 }
@@ -116,6 +299,18 @@ func (t Tokenizer) unexpectedLineBreak() error {
 	return UnexpectedLinebreakErr{line: t.line, idx: t.idx}
 }
 
+func (t Tokenizer) unexpectedKeyword(n string) error {
+	return UnexpectedTokenErr{idx: t.idx, line: t.line, token: n}
+}
+
+func (t Tokenizer) invalidConditionalExpression(expr string) error {
+	return InvalidConditionalExpressionErr{idx: t.idx, line: t.line, expr: expr}
+}
+
+func (t Tokenizer) unsupportedConditionalHelper(name string) error {
+	return UnsupportedConditionalHelperErr{idx: t.idx, line: t.line, helper: name}
+}
+
 // Feed feeds a given rune to the parser
 func (t *Tokenizer) Feed(chr rune) error {
 	defer func() {
@@ -125,11 +320,18 @@ func (t *Tokenizer) Feed(chr rune) error {
 		}
 		t.lastFedRune = chr
 	}()
-	switch t.state {
+	if DEBUG {
+		pchr := string(chr)
+		if pchr == "\n" {
+			pchr = "\\n"
+		}
+		debug("CHR: %s, STATE: %s\n", pchr, t._state)
+	}
+	switch t._state {
 	case stateLiteral:
 		if chr == DELIM && t.lastRune() != ESCAPE {
 			t.commitLiteral()
-			t.state = stateTemplateName
+			t.transition(stateTemplateName)
 			return nil
 		} else if chr == DELIM && t.lastRune() == ESCAPE {
 			t.tmp.DeleteLast()
@@ -141,16 +343,63 @@ func (t *Tokenizer) Feed(chr rune) error {
 			if t.templateName.Len() == 0 {
 				return t.unexpectedToken(DELIM)
 			}
+			currentName := t.templateName.String()
+			if currentName == "if" {
+				return t.unexpectedKeyword(currentName)
+			} else if currentName == "else" {
+				if ok, ss := t.currentStack(); !ok {
+					return t.unexpectedKeyword(currentName)
+				} else if ss == stateTemplateConditionalElseIf {
+					t.popStack()
+					parent := t.currentConditional.Parent()
+					if parent == nil || reflect.ValueOf(parent).IsNil() {
+						panic("BUG: ElseIf without parent")
+					} else if parent.Kind() != KindConditional {
+						panic("BUG: ElseIf without conditional parent")
+					}
+					t.currentConditional = parent.(*Conditional)
+				}
+
+				t.replaceStack(stateTemplateConditionalElse)
+				t.transition(stateLiteral)
+				t.templateName.Reset()
+				return nil
+			} else if currentName == "endif" {
+				if ok, _ := t.currentStack(); !ok {
+					return t.unexpectedKeyword(currentName)
+				}
+				t.popStack()
+				prevCond := t.currentConditional.Parent()
+				if prevCond == nil || reflect.ValueOf(prevCond).IsNil() {
+					t.currentConditional = nil
+				} else if prevCond.Kind() != KindConditional {
+					panic("BUG? Parent is not conditional")
+				}
+				t.currentConditional = prevCond.(*Conditional)
+				t.transition(stateLiteral)
+				t.templateName.Reset()
+				return nil
+			}
 			t.commitTemplate()
-			t.state = stateLiteral
+			t.transition(stateLiteral)
 			return nil
 		} else if chr == SPACE {
 			return t.unexpectedToken(SPACE)
 		} else if chr == SEMICOLON {
-			t.state = stateTemplateOptionName
+			t.transition(stateTemplateOptionName)
 			return nil
 		} else if chr == NEWLINE {
 			return t.unexpectedLineBreak()
+		} else if chr == LPAREN && (t.templateName.String() == "if" || t.templateName.String() == "elseif") {
+			if t.templateName.String() == "if" {
+				t.transition(stateTemplateConditionalThen)
+			} else {
+				t.transition(stateTemplateConditionalElseIf)
+			}
+			t.pushStack()
+			t.transition(stateTemplateConditionalExpression)
+			t.templateName.Reset()
+			return nil
 		}
 		if t.templateName.Len() == 0 && !unicode.IsLetter(chr) {
 			return t.unexpectedToken(chr)
@@ -160,16 +409,38 @@ func (t *Tokenizer) Feed(chr rune) error {
 		}
 		t.templateName.WriteRune(chr)
 
+	case stateTemplateConditionalExpression:
+		if chr == RPAREN {
+			if t.templateName.Len() == 0 {
+				return t.unexpectedToken(chr)
+			}
+			t.transition(stateTemplateConditionalExpressionEnd)
+			return nil
+		}
+		if !unicode.IsLetter(chr) && !unicode.IsDigit(chr) && chr != DOT {
+			return t.unexpectedToken(chr)
+		}
+		t.templateName.WriteRune(chr)
+
+	case stateTemplateConditionalExpressionEnd:
+		if chr != DELIM {
+			return t.unexpectedToken(chr)
+		}
+		if err := t.prepareConditional(); err != nil {
+			return err
+		}
+		t.transition(stateLiteral)
+
 	case stateTemplateOptionName:
 		if chr == DELIM {
 			if t.templateName.Len() == 0 {
 				return t.unexpectedToken(DELIM)
 			}
 			t.commitTemplate()
-			t.state = stateLiteral
+			t.transition(stateLiteral)
 			return nil
 		} else if chr == EQUALS {
-			t.state = stateTemplateOptionValueBegin
+			t.transition(stateTemplateOptionValueBegin)
 			return nil
 		}
 		t.optionName.WriteRune(chr)
@@ -178,14 +449,14 @@ func (t *Tokenizer) Feed(chr rune) error {
 		if isSpace(chr) {
 			return nil
 		} else if chr == QUOT {
-			t.state = stateTemplateOptionValue
+			t.transition(stateTemplateOptionValue)
 			return nil
 		}
 		return t.unexpectedToken(chr)
 
 	case stateTemplateOptionValue:
 		if chr == QUOT && t.lastRune() != ESCAPE {
-			t.state = stateTemplateOptionOrEnd
+			t.transition(stateTemplateOptionOrEnd)
 			t.commitTemplateOption()
 			return nil
 		} else if chr == QUOT && t.lastRune() == ESCAPE {
@@ -197,10 +468,10 @@ func (t *Tokenizer) Feed(chr rune) error {
 		if isSpace(chr) {
 			return nil
 		} else if chr == COMMA {
-			t.state = stateTemplateOptionName
+			t.transition(stateTemplateOptionName)
 			return nil
 		} else if chr == DELIM {
-			t.state = stateLiteral
+			t.transition(stateLiteral)
 			t.commitTemplate()
 			return nil
 		}
@@ -213,11 +484,11 @@ func (t *Tokenizer) Feed(chr rune) error {
 // Finish completes the parsing process and returns the generated AST, or an
 // error
 func (t *Tokenizer) Finish() (AST, error) {
-	if t.state != stateLiteral {
+	if t._state != stateLiteral {
 		return nil, UnexpectedEOFErr{
 			idx:   t.idx,
 			line:  t.line,
-			state: t.state,
+			state: t._state,
 		}
 	}
 

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -43,3 +43,27 @@ func TestEscapes01(t *testing.T) {
 	_, err := Tokenize(template)
 	require.NoError(t, err)
 }
+
+func TestConditional(t *testing.T) {
+	template := "$if(foobar.truthy)$foo$endif$"
+	_, err := Tokenize(template)
+	require.NoError(t, err)
+}
+
+func TestConditionalElse(t *testing.T) {
+	template := "$if(foobar.truthy)$foo$else$bar$endif$"
+	_, err := Tokenize(template)
+	require.NoError(t, err)
+}
+
+func TestConditionalElseIf(t *testing.T) {
+	template := `$if(foobar.truthy)$
+foo
+$elseif(foobar.truthy)$
+bar
+$else$
+baz
+$endif$`
+	_, err := Tokenize(template)
+	require.NoError(t, err)
+}

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -67,3 +67,15 @@ $endif$`
 	_, err := Tokenize(template)
 	require.NoError(t, err)
 }
+
+func TestConditionalUnorderedStructure(t *testing.T) {
+	template := `$if(foobar.truthy)$
+foo
+$else$
+bar
+$elseif(foobar.truthy)$
+baz
+$endif$`
+	_, err := Tokenize(template)
+	require.Error(t, err)
+}

--- a/props/props.go
+++ b/props/props.go
@@ -15,6 +15,18 @@ const (
 )
 
 type Pair struct{ K, V string }
+
+var truthyValues = []string{"yes", "y", "true"}
+
+func (p Pair) Truthy() bool {
+	for _, v := range truthyValues {
+		if strings.EqualFold(p.V, v) {
+			return true
+		}
+	}
+	return false
+}
+
 type Pairs []Pair
 
 // Find returns a Pair with with name, or nil
@@ -35,6 +47,15 @@ func (p *Pairs) Fetch(name string) (string, bool) {
 	} else {
 		return "", false
 	}
+}
+
+// FetchPair attempts to find a pair with a given name, and returns the pair
+// representation and true. Returns nil and false otherwise.
+func (p *Pairs) FetchPair(name string) (*Pair, bool) {
+	if pair := p.Find(name); pair != nil {
+		return pair, true
+	}
+	return nil, false
 }
 
 // Map transforms a given Pairs slice into a map

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -1,0 +1,34 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Gympass/go-giter8/lexer"
+	"github.com/Gympass/go-giter8/props"
+	"github.com/Gympass/go-giter8/render"
+)
+
+func TestRendering(t *testing.T) {
+	template := `$if(ok.truthy)$
+OK!
+$endif$
+$if(notok.truthy)$
+NOTOK
+$endif$`
+
+	p := props.FromMap(map[string]string{
+		"ok":    "yes",
+		"notok": "tchubaruba",
+	})
+
+	ast, err := lexer.Tokenize(template)
+	require.NoError(t, err)
+
+	exec := render.NewExecutor(p)
+	r, err := exec.Exec(ast)
+	require.NoError(t, err)
+	assert.Equal(t, "\nOK!\n\n", r)
+}


### PR DESCRIPTION
This implements support for conditionals. Conditionals can now be used with a single `truthy` helper, just like the following example:

Given a property pair:

```go
p := pairs.FromMap(map[string]string{"prop_name": "true"})
```

and a template:

```
$if(prop_name.truthy)$
foo
$else$
bar
$endif$
```

the following would be rendered:

```
foo
```

`truthy` checks for the following values in a case-insensitive manner: `yes`, `y`, `true`. All other values are considered as `false`.

## Known problems

1. Empty lines are not stripped within a conditional block. For instance, a block with the following characters: `$if(foo.truthy)$\nfoo\n$else$\nbar\n$endif$` would be rendered as `\nfoo\n` in case `foo` equals `true`.
~~2. If-elseif-else orders are not respected. One is able to write an `if-else-elseif` structure and it will be executed as `if-elseif-else`.~~ Addressed by 4af06ab8d99ee30ea625259f01d8d50c65cfc434