### PR TITLE
fix(lexer): Implement cleanAST to remove extra spaces

### DIFF
--- a/test/main_test.go
+++ b/test/main_test.go
@@ -30,5 +30,5 @@ $endif$`
 	exec := render.NewExecutor(p)
 	r, err := exec.Exec(ast)
 	require.NoError(t, err)
-	assert.Equal(t, "\nOK!\n\n", r)
+	assert.Equal(t, "\nOK!\n", r)
 }


### PR DESCRIPTION
This ensures single Literals containing a single line break between conditionals are stripped out, yielding fewer empty lines