### PR TITLE
feat(fs): Implement conditional support to FS items

### DIFF
--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -1,6 +1,7 @@
 package lexer
 
 import (
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -78,4 +79,19 @@ baz
 $endif$`
 	_, err := Tokenize(template)
 	require.Error(t, err)
+}
+
+func TestCompositeFormatting(t *testing.T) {
+	template := `$name__decap$`
+	ast, err := Tokenize(template)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(ast))
+	node := ast[0]
+	assert.Equal(t, KindTemplate, node.Kind())
+	tmp := node.(*Template)
+	assert.Equal(t, "name", tmp.Name)
+	assert.Equal(t, 1, len(tmp.Options))
+	fmt, ok := tmp.Options["format"]
+	assert.True(t, ok)
+	assert.Equal(t, "decap", fmt)
 }

--- a/render/template.go
+++ b/render/template.go
@@ -100,6 +100,11 @@ func renderAndJoin(exec *Executor, nodes []fs.Node) (string, error) {
 		if r, err := exec.Exec(n.Name); err != nil {
 			return "", err
 		} else {
+			if r == "" {
+				// If a single item yields an empty string, we can safely
+				// invalidate all the path and do not work on this fs node
+				return "", nil
+			}
 			items = append(items, r)
 		}
 	}
@@ -133,7 +138,9 @@ func TemplateDirectory(props props.Pairs, source, destination string) error {
 		if err != nil {
 			return err
 		}
-
+		if path == "" {
+			continue
+		}
 		path = filepath.Join(destination, path)
 
 		if item.IsDir {


### PR DESCRIPTION
This implements support to conditional file items. For instance, considering the following directory structure:

```
├── directory
│   └── file.txt
└── $if(foo.truthy)$bar$end$
    └── otherfile.txt
```

And props as:
```
foo = n
```

Rendering this directory template will yield the following structure:

```
└── directory
    └── file.txt
```

And having `foo` defined as any `truthy` value (such as `yes`, `y`, or `true`) yields the following structure:

```
├── directory
│   └── file.txt
└── bar
    └── otherfile.txt
```