### PR TITLE
fix(fs): Ensure default.properties is not included in rendered templates

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -35,7 +35,7 @@ func ScanTree(source string) ([]TreeItem, error) {
 		if err != nil {
 			return err
 		}
-		if path == source {
+		if path == source || strings.EqualFold(filepath.Join(source, "default.properties"), path) {
 			return nil
 		}
 


### PR DESCRIPTION
This ensure template directories rendered with `/TemplateDirectory(Opts)?/` do not carry `default.properties` from their templates.