### PR TITLE
[PRT-90] feat(lexer): Implement support to dashed variables

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -139,6 +139,7 @@ const (
 	RPAREN     = rune(')')
 	DOT        = rune('.')
 	UNDERSCORE = rune('_')
+	DASH       = rune('-')
 	TRUTHY     = "truthy"
 )
 
@@ -445,7 +446,7 @@ func (t *Tokenizer) Feed(chr rune) error {
 			t.tmp.Reset()
 			return nil
 		}
-		if !unicode.IsLetter(chr) && !unicode.IsDigit(chr) && chr != UNDERSCORE {
+		if !unicode.IsLetter(chr) && !unicode.IsDigit(chr) && chr != UNDERSCORE && chr != DASH {
 			return t.unexpectedToken(chr)
 		}
 		t.templateName.WriteRune(chr)

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -1,9 +1,9 @@
 package lexer
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -94,4 +94,15 @@ func TestCompositeFormatting(t *testing.T) {
 	fmt, ok := tmp.Options["format"]
 	assert.True(t, ok)
 	assert.Equal(t, "decap", fmt)
+}
+
+func TestDashedVariables(t *testing.T) {
+	template := "$some-variable$"
+	ast, err := Tokenize(template)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(ast))
+	node := ast[0]
+	assert.Equal(t, KindTemplate, node.Kind())
+	tmp := node.(*Template)
+	assert.Equal(t, "some-variable", tmp.Name)
 }

--- a/props/props_test.go
+++ b/props/props_test.go
@@ -17,6 +17,7 @@ minimumCoverage=10
 descriptions=Project descriptions
 namespace=foo
 productionCluster=production
+dashed-variable=value
 `
 	allProps, err := ParseProperties(props)
 	require.NoError(t, err)
@@ -28,4 +29,5 @@ productionCluster=production
 	assert.Equal(t, "10", allProps.MustGet("minimumCoverage"))
 	assert.Equal(t, "foo", allProps.MustGet("namespace"))
 	assert.Equal(t, "production", allProps.MustGet("productionCluster"))
+	assert.Equal(t, "value", allProps.MustGet("dashed-variable"))
 }

--- a/render/renderer_test.go
+++ b/render/renderer_test.go
@@ -1,0 +1,24 @@
+package render
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Gympass/go-giter8/lexer"
+	"github.com/Gympass/go-giter8/props"
+)
+
+func TestRenderer(t *testing.T) {
+	template := `$dashed-variable$`
+	ast, err := lexer.Tokenize(template)
+	require.NoError(t, err)
+	prps := props.FromMap(map[string]string{
+		"dashed-variable": "foo",
+	})
+	exec := NewExecutor(prps)
+	res, err := exec.Exec(ast)
+	require.NoError(t, err)
+	assert.Equal(t, "foo", res)
+}


### PR DESCRIPTION
This implements support to dashed variables, allowing variables like `a-name` to be used.