### PR TITLE
[PRT-94] Allow properties used in conditionals to be absent

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -340,6 +340,10 @@ func (t Tokenizer) unsupportedConditionalHelper(name string) error {
 	return UnsupportedConditionalHelperErr{idx: t.idx, line: t.line, helper: name}
 }
 
+func isValidNameChar(chr rune) bool {
+	return unicode.IsLetter(chr) || unicode.IsDigit(chr) || chr == DASH || chr == UNDERSCORE
+}
+
 // Feed feeds a given rune to the parser
 func (t *Tokenizer) Feed(chr rune) error {
 	defer func() {
@@ -446,7 +450,7 @@ func (t *Tokenizer) Feed(chr rune) error {
 			t.tmp.Reset()
 			return nil
 		}
-		if !unicode.IsLetter(chr) && !unicode.IsDigit(chr) && chr != UNDERSCORE && chr != DASH {
+		if !isValidNameChar(chr) {
 			return t.unexpectedToken(chr)
 		}
 		t.templateName.WriteRune(chr)
@@ -473,7 +477,7 @@ func (t *Tokenizer) Feed(chr rune) error {
 			t.transition(stateTemplateConditionalExpressionEnd)
 			return nil
 		}
-		if !unicode.IsLetter(chr) && !unicode.IsDigit(chr) && chr != DOT {
+		if !isValidNameChar(chr) && chr != DOT {
 			return t.unexpectedToken(chr)
 		}
 		t.templateName.WriteRune(chr)

--- a/render/executor.go
+++ b/render/executor.go
@@ -181,7 +181,7 @@ func (e *Executor) runMethods(t *lexer.Template) (string, error) {
 func (e *Executor) evaluateConditionalExpression(expr, helper string) (bool, error) {
 	v, ok := e.props.FetchPair(expr)
 	if !ok {
-		return false, fmt.Errorf("property `%s' is not defined", expr)
+		return false, nil
 	}
 	if strings.EqualFold(helper, "truthy") {
 		return v.Truthy(), nil

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -54,3 +54,25 @@ $endif$`
 	require.NoError(t, err)
 	assert.Equal(t, "", r)
 }
+
+func TestAbsentConditionalProperties(t *testing.T) {
+	template := `$if(non-existing.truthy)$
+$non-existing$
+$endif$
+$if(existing.truthy)$
+Yay!
+$endif$`
+
+	p := props.FromMap(map[string]string{
+		"existing": "true",
+	})
+
+	ast, err := lexer.Tokenize(template)
+	require.NoError(t, err)
+
+	exec := render.NewExecutor(p)
+	r, err := exec.Exec(ast)
+	require.NoError(t, err)
+	assert.Equal(t, "\nYay!\n", r)
+
+}


### PR DESCRIPTION
This relaxes property checking to allow absent properties to be checked for their presence.
This also fixes an inconsistency that prevented properties containing dashes (`-`) from being used in conditional expressions. 