### PR TITLE
[PRT-128] feat: Implement 'present' conditional

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -141,7 +141,13 @@ const (
 	UNDERSCORE = rune('_')
 	DASH       = rune('-')
 	TRUTHY     = "truthy"
+	PRESENT    = "present"
 )
+
+var validComparators = map[string]bool{
+	TRUTHY:  true,
+	PRESENT: true,
+}
 
 func isSpace(r rune) bool {
 	return r == SPACE || r == HTAB
@@ -290,7 +296,7 @@ func (t *Tokenizer) prepareConditional() error {
 		helper = expr[separatorIndex+1:]
 	)
 
-	if !strings.EqualFold(helper, TRUTHY) {
+	if _, ok := validComparators[strings.ToLower(helper)]; !ok {
 		return t.unsupportedConditionalHelper(helper)
 	}
 

--- a/render/executor.go
+++ b/render/executor.go
@@ -183,8 +183,11 @@ func (e *Executor) evaluateConditionalExpression(expr, helper string) (bool, err
 	if !ok {
 		return false, nil
 	}
-	if strings.EqualFold(helper, "truthy") {
+	switch true {
+	case strings.EqualFold(helper, "truthy"):
 		return v.Truthy(), nil
+	case strings.EqualFold(helper, "present"):
+		return len(strings.TrimSpace(v.V)) != 0, nil
 	}
 	panic("BUG: helper allowed by lexer, but not implemented by renderer")
 }

--- a/test/main_test.go
+++ b/test/main_test.go
@@ -76,3 +76,25 @@ $endif$`
 	assert.Equal(t, "\nYay!\n", r)
 
 }
+
+func TestPresentConditional(t *testing.T) {
+	template := `$if(non-existing.present)$
+$non-existing$
+$endif$
+$if(existing.present)$
+foobar
+$endif$`
+
+	p := props.FromMap(map[string]string{
+		"existing": "foobar",
+	})
+
+	ast, err := lexer.Tokenize(template)
+	require.NoError(t, err)
+
+	exec := render.NewExecutor(p)
+	r, err := exec.Exec(ast)
+	require.NoError(t, err)
+	assert.Equal(t, "\nfoobar\n", r)
+
+}


### PR DESCRIPTION
This implements a new `present` conditional helper, which allows us to check for whether a property is defined, and it is not empty.
