### PR TITLE
[PRT-149] feat(AST): Implement IsPureLiteral

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -77,6 +77,17 @@ func (c Conditional) Parent() Node {
 
 type AST []Node
 
+// IsPureLiteral determines whether the AST only contains literals, meaning
+// it contains no templating to be processed
+func (a AST) IsPureLiteral() bool {
+	for _, n := range a {
+		if n.Kind() != KindLiteral {
+			return false
+		}
+	}
+	return true
+}
+
 type state int
 
 const (

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -106,3 +106,10 @@ func TestDashedVariables(t *testing.T) {
 	tmp := node.(*Template)
 	assert.Equal(t, "some-variable", tmp.Name)
 }
+
+func TestAST_IsPureLiteral(t *testing.T) {
+	template := "A pure-literal \\$value"
+	ast, err := Tokenize(template)
+	require.NoError(t, err)
+	assert.True(t, ast.IsPureLiteral())
+}


### PR DESCRIPTION
This implements a simple `IsPureLiteral` method to `AST` in order to detect ASTs containing only literal values